### PR TITLE
Fix for the month selection where there is no day for a host

### DIFF
--- a/varwww/html/index.php
+++ b/varwww/html/index.php
@@ -336,7 +336,7 @@ if (!$empty_iplist) {
         }
     }
     if (isset($hostmonthlist[$_SESSION['showip']])) {
-        foreach ($hostdaylist[$_SESSION['showip']] as $day) {
+        foreach ($hostmonthlist[$_SESSION['showip']] as $day) {
             if (!isset($_SESSION['day'])) {
                 $_SESSION['day'] = $day;
                 break;


### PR DESCRIPTION
Fix for the month selection where there is no day for a host (possible unused/unnamed host).

Fixed #8 