### PR TITLE
Removed centos7 support and added php8.2. Fixed two minor bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,18 @@ A Syslog-NG to MySQL parser with no-nonsense frontend
 
 ### Requirements
 
+- Apache httpd 2.4
 - Syslog-NG 3.3 or newer
-- PHP 7.4 or newer, prefered 8.0/8.1
-- MySQL 8.0 or equivalent (like MariaDB 10.x)
+- PHP 8.1/8.2
+- MariaDB 10.x, MySQL 8.0 or equivalent
 
-_Build, developped and tested on Centos7.9, Syslog-NG 3.36, Apache 2.4 PHP 7.4 and 8.0/8.1, MariaDB 10.6_
+_Build, developped and tested on Centos7.9, Ubuntu20/22, AlmaLinux 8/9, Syslog-NG 3.3x, Apache 2.4, PHP 7.4 and 8.0/8.1/8.2, MariaDB 10.6_
 
 ### External software
 Provided within this repository
 
 - TrueType (msttcore) fonts
-- JpGraph 4.4.1 (https://jpgraph.net/)
+- JpGraph 4.4.2 (https://jpgraph.net/)
 
 ### Features
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,13 +13,13 @@ depending on the number of hosts logging and sheer number of lines logged.
   It was originaly written for Syslog-NG 2.x, so as long as it can send
   formatted lines to the FiFo file, you're good.
 
-- PHP 7.4 or newer, prefered 8.0/8.1
+- PHP 8.1/8.2
 
   It is possible that it could work on earlier PHP versions. No guarantee.
-  Required modules: php php-cli php-common php-gd php-pear php-memcache
-  php-xml php-mysql(nd)
+  Required modules: php-common php-memcache php-process php-mbstring
+  php-xml php-mysql(nd). It should be compatible with 7.4 and 8.0.
 
-- MySQL 8.0 or equivalent (like MariaDB 10.x)
+- MariaDB 10.x, MySQL 8.0 or equivalent
 
   It could work on earlier versions as there are no MySQL >8.0 specific
   database or table settings. No guarantee.
@@ -67,7 +67,7 @@ Start the installation: ```bash install.sh```
 
 And there you have it. 
 
-The installation script is made for CentOS 7 and is compatible with 
+The installation script is made for RHEL8/9 and is compatible with 
 AlmaLinux 9.x and Ubuntu (22.04 to be precise), the so-called LAMP stack.
 Anyone with a little knowledge of Bash/Shell could make it work for your
 distribution. The script does several checks if software or locations are 
@@ -77,16 +77,16 @@ available, not in use, made or can be made. No rocket science.
 
 Perhaps you want the full help on a clean install. This should work out of 
 the box with a normal new installation. Given that your enabled repo's provide 
-PHP 7.4 or newer.
+PHP 8.1/8.2 or newer.
 
-**CentOS 7 / AlmaLinux / RHEL-like**
-
+**RHEL 8/9 / AlmaLinux 8/9**
 
 ```
-sudo yum remove -y rsyslog
-sudo yum install -y syslog-ng
-sudo yum install -y git php php-cli php-common php-gd php-pear php-memcache php-xml php-mysqlnd httpd
-sudo yum install -y mariadb-server mariadb-server-utils mariadb
+sudo dnf remove -y rsyslog
+sudo dnf install -y syslog-ng
+sudo dnf install -y git php php-cli php-common php-memcache php-mbstring php-mysqlnd php-process httpd
+sudo dnf install -y mariadb-server mariadb-server-utils mariadb
+sudo systemctl enable --now php-fpm httpd mariadb syslog-ng
 sudo mysql_secure_installation
 
 sudo vi /root/.my.cnf
@@ -98,7 +98,7 @@ password="whatyouentered"
 cd /usr/local/src
 sudo git clone https://github.com/barreljan/netlog
 cd netlog/install
-sudo bash install.sh
+sudo bash install.sh```
 ```
 
 **Ubuntu 22.xx**
@@ -106,8 +106,9 @@ sudo bash install.sh
 ```
 sudo apt remove rsyslog
 sudo apt install syslog-ng
-sudo apt install php php-cli php-common php-gd php-pear php-memcache php-xml php-mysql
+sudo apt install php php-cli php-common php-memcache php-process php-mbstring php-mysql httpd
 sudo apt install mariadb-server mariadb-client
+sudo systemctl enable --now php-fpm httpd mariadb syslog-ng
 sudo mysql_secure_installation
 
 sudo vi /root/.my.cnf

--- a/etc/global.php
+++ b/etc/global.php
@@ -3,7 +3,7 @@
 // Project: https://github.com/barreljan/netlog
 
 // Versioning etc
-const VERSION = 'v3.0.5';
+const VERSION = 'v3.0.7';
 const NAME = 'Syslog-ng to MySQL parser';
 const AUTHOR = 'bartjan@pc-mania.nl';
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -3,7 +3,7 @@
 #
 # This installation script provides a decent checked out setup for Netlog.
 #
-# Currently working (and tested) for: CentOS 7, Ubuntu (22.04)
+# Currently working (and tested) for: CentOS 7, AlmaLinux 9, Ubuntu (22.04)
 #
 # However:
 # You running this script/function means you will not blame the author(s)
@@ -62,7 +62,7 @@ APACHE2_CONF_ADIR=/etc/apache2/conf-available
 APACHE2_CONF_EDIR=/etc/apache2/conf-enabled
 CROND_DIR=/etc/cron.d
 NETLOG_PASS="$(random_pass)"
-JPGRAPH_VER="4.4.1"
+JPGRAPH_VER="4.4.2"
 # MySQL setup
 TEMPDIR=$(mktemp -d)
 CNFFILE="/root/.my.cnf"

--- a/utils/offenders.php
+++ b/utils/offenders.php
@@ -142,6 +142,10 @@ while ($row = $linesresult->fetch_assoc()) {
             $ip_address = explode($options['delimiter'], $field);
             if (sizeof($ip_address) == 2) {
                 $ip = $ip_address[1];
+                // Fix for ASA; -s outside -D : -m "Deny tcp src"
+                if (str_contains($ip, "/")) {
+                    $ip = explode("/", $ip)[0];
+                }
                 if (key_exists($ip, $offenders)) {
                     // already accounted for
                     $offenders[$ip] += 1;
@@ -153,6 +157,7 @@ while ($row = $linesresult->fetch_assoc()) {
         }
     }
 }
+
 
 // print out data, if there is any
 if (sizeof($offenders) >= 1) {

--- a/web/netalert.php
+++ b/web/netalert.php
@@ -96,7 +96,7 @@ try {
                                     $timestamp = strtotime($loglines["TIME"]);
                                     $timediff = $currenttime - $timestamp;
                                     foreach ($alert_fields as $column) {
-                                        if ($column == "TIME") {
+                                        if ($column == "TIME" || $column == "DAY") {
                                             switch ($timediff) {
                                                 case ($timediff < 400):
                                                     echo "<td class=\"panic\"><b>" . $loglines[$column] . "</b></td>";


### PR DESCRIPTION
Decommisioned Centos7 as it is EoL since 30 jun '24. Also added the support for PHP8.2 and therefor added the jpgraph-4.4.2 release to support 8.2. Both have been tested since a while on a Centos7 and AlmaLinux 9.4 system.